### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(
     ],
     entry_points='''
         [console_scripts]
-        srcfilesnetwork=srcfilesnetwork:cli
+        srcfilesnetwork=srcfilesnetwork:plotnetwork 
     ''',
 )


### PR DESCRIPTION
change `cli` to the actual name of the function `plotnetwork` so the script can be called directly from terminal without need to call python:

`python srcfilesnetwork.py PATH` or `python -m scrfilesnetwork PATH` can be substituted by simply `srcfilesnetwork PATH` 

after making the change in setup, srcfilesnetwork need to be installed via: `pip install --editable .`